### PR TITLE
[STABLE] block submission in async submitForm

### DIFF
--- a/src/react-forms.js
+++ b/src/react-forms.js
@@ -415,8 +415,8 @@ class ReactForms extends Component {
       return false;
     }
 
-    await this.startSubmit();
     this.blockSubmission = true;
+    await this.startSubmit();
 
     const maybePromisedErrors = this.runValidations();
 

--- a/src/react-forms.js
+++ b/src/react-forms.js
@@ -385,7 +385,6 @@ class ReactForms extends Component {
           ...prevState,
           isSubmitting: true
         }));
-        this.blockSubmission = true;
         const submit = handleSubmit(values, this.getFormHelpers(true));
         if (isPromise(submit)) {
           const submission = await submit;
@@ -401,7 +400,6 @@ class ReactForms extends Component {
         ...prevState,
         isSubmitting: false
       }));
-      this.blockSubmission = false;
     }
   }
 
@@ -418,6 +416,7 @@ class ReactForms extends Component {
     }
 
     await this.startSubmit();
+    this.blockSubmission = true;
 
     const maybePromisedErrors = this.runValidations();
 
@@ -428,7 +427,9 @@ class ReactForms extends Component {
       await this.setErrors(maybePromisedErrors, false, true);
     }
 
-    return this.executeSubmit();
+    const result = await this.executeSubmit();
+    this.blockSubmission = false;
+    return result;
   }
 
   getComputedProps () {


### PR DESCRIPTION
In https://github.com/aaronnuu/react-forms/pull/4 submission was blocked in submitForm but the flag was set in executeSubmit which allowed for submitForm to be run more than once. This PR Fixes that issue by moving the flag AND check both into submitForm.