### PR TITLE
Catch submit errors

### DIFF
--- a/src/react-forms.js
+++ b/src/react-forms.js
@@ -416,20 +416,24 @@ class ReactForms extends Component {
     }
 
     this.blockSubmission = true;
-    await this.startSubmit();
+    try {
+      await this.startSubmit();
 
-    const maybePromisedErrors = this.runValidations();
+      const maybePromisedErrors = this.runValidations();
 
-    if (isPromise(maybePromisedErrors)) {
-      const errors = await maybePromisedErrors;
-      await this.setErrors(errors, false, true);
-    } else {
-      await this.setErrors(maybePromisedErrors, false, true);
+      if (isPromise(maybePromisedErrors)) {
+        const errors = await maybePromisedErrors;
+        await this.setErrors(errors, false, true);
+      } else {
+        await this.setErrors(maybePromisedErrors, false, true);
+      }
+
+      const result = await this.executeSubmit();
+      this.blockSubmission = false;
+      return result;
+    } catch (e) {
+      this.blockSubmission = false;
     }
-
-    const result = await this.executeSubmit();
-    this.blockSubmission = false;
-    return result;
   }
 
   getComputedProps () {


### PR DESCRIPTION
Rn we're not reseting the submit blocker properly if the submit function itself throws. This fixes it 🤞 